### PR TITLE
Support HTTP 451 Unavailable For Legal Reasons

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -58,6 +58,7 @@ class Response
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',
+        451 => 'Unavailable For Legal Reasons',
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',


### PR DESCRIPTION
RFC(draft) https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05
