### PR TITLE
Enabling user to set a logger instance on the config file

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -15,7 +15,6 @@ use Dietcube\Exception\DCException;
 use Dietcube\Exception\HttpNotFoundException;
 use Dietcube\Exception\HttpMethodNotAllowedException;
 use Dietcube\Twig\DietcubeExtension;
-use Monolog\Formatter\FormatterInterface;
 use Pimple\Container;
 use FastRoute\Dispatcher as RouteDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcher;


### PR DESCRIPTION
# What's this PR

Since we couldn't control settings of the logger in detail, as the logger is set in a internal method of Dispatcher.php.
I'd like to set a logger instance on the config file, so that we can set  a formatter or other setting of a logger.
This PR allows user to set a logger instance on the config file.

This is a sample of config.
Just add a 'logger' key and a logger instance as a value.

```
    'logger' => [
        'logger' => new \Monolog\Logger('app',
            [
                (new \Monolog\Handler\StreamHandler(
                    '/path/to/your.log',
                    \Monolog\Logger::DEBUG
                ))->setFormatter(new \Monolog\Formatter\JsonFormatter())
            ]
        ),
    ],
```
# Break BC ?

**no**

You can still use the original setting like this.

```
    'logger' => [
        'path' =>  '/path/to/your.log',
        'level' => \Monolog\Logger::DEBUG,
    ],
```
