### PR TITLE
throw exception when the config file does not exist

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -57,7 +57,7 @@ abstract class Application
         foreach ($this->getConfigFiles() as $config_file) {
             $load_config_file = $this->getConfigDir() . '/' .  $config_file;
             if (!file_exists($load_config_file)) {
-                continue;
+                throw new DCException('config file not found :' . $load_config_file);
             }
 
             $config = array_merge($config, require $load_config_file);


### PR DESCRIPTION
In enterprise use cases ( I mean, not in personal use), we normally have config files for each environment, like config-development.php, config-production.php, etc.

I suppose we would be more happy if the framework raised error instead of going ahead when users forgot to make config files.
This PR would reduce the time of trouble shooting for users.
