### PR TITLE
avoid phpunit warnings

### DIFF
--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -63,8 +63,6 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testSetVars()
     {
         $app = $this->getMockBuilder('\Dietcube\Application')->disableOriginalConstructor()->getMockForAbstractClass();
-        $app->expects($this->any())->method('getTemplateExt')->will($this->returnValue('.html.twig'));
-
         $renderer = $this->getMock('Twig_Environment');
         $renderer->expects($this->any())->method('render')->will($this->returnArgument(1));
 
@@ -83,7 +81,6 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testRenderVars()
     {
         $app = $this->getMockBuilder('\Dietcube\Application')->disableOriginalConstructor()->getMockForAbstractClass();
-        $app->expects($this->any())->method('getTemplateExt')->will($this->returnValue('.html.twig'));
 
         $renderer = $this->getMock('Twig_Environment');
         $renderer->expects($this->any())->method('render')->will($this->returnArgument(1));


### PR DESCRIPTION
it seems that we should create a Mock Class to configure `getTemplateExt` like this, 

https://github.com/sebastianbergmann/phpunit-mock-objects/blob/master/tests/MockObject/Generator/232.phpt#L60

I suppose this PR would be enough to avoid warnings.
