### PR TITLE
Enabling user to set a logger instance on your own Application class

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -8,6 +8,10 @@ namespace Dietcube;
 use Dietcube\Components\ContainerAwareTrait;
 use Dietcube\Exception\DCException;
 use Pimple\Container;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\ErrorLogHandler;
+use Monolog\Processor\PsrLogMessageProcessor;
 
 abstract class Application
 {
@@ -241,5 +245,24 @@ abstract class Application
     {
         $ref = new \ReflectionObject($this);
         return $ref->getNamespaceName();
+    }
+
+    public function createLogger($path, $level = Logger::WARNING)
+    {
+        $logger = new Logger('app');
+        $logger->pushProcessor(new PsrLogMessageProcessor);
+
+        if (is_writable($path) || is_writable(dirname($path))) {
+            $logger->pushHandler(new StreamHandler($path, $level));
+        } else {
+            if ($this->isDebug()) {
+                throw new DCException("Log path '{$path}' is not writable. Make sure your logger.path of config.");
+            }
+            $logger->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, $level));
+            $logger->warning("Log path '{$path}' is not writable. Make sure your logger.path of config.");
+            $logger->warning("error_log() is used for application logger instead at this time.");
+        }
+
+        return $logger;
     }
 }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -20,9 +20,6 @@ use FastRoute\Dispatcher as RouteDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
 use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Monolog\Handler\ErrorLogHandler;
-use Monolog\Processor\PsrLogMessageProcessor;
 
 class Dispatcher
 {
@@ -58,7 +55,7 @@ class Dispatcher
         $this->app->setContainer($container);
         $config = $this->container['app.config'] = $this->app->getConfig();
 
-        $this->container['logger'] = $logger = $this->createLogger(
+        $this->container['logger'] = $logger = $this->app->createLogger(
             $config->get('logger.path'),
             $config->get('logger.level', Logger::WARNING)
         );
@@ -83,25 +80,6 @@ class Dispatcher
         $this->app->config($this->container);
 
         $this->event_dispatcher->dispatch(DietcubeEvents::BOOT, new BootEvent($this->app));
-    }
-
-    protected function createLogger($path, $level = Logger::WARNING)
-    {
-        $logger = new Logger('app');
-        $logger->pushProcessor(new PsrLogMessageProcessor);
-
-        if (is_writable($path) || is_writable(dirname($path))) {
-            $logger->pushHandler(new StreamHandler($path, $level));
-        } else {
-            if ($this->app->isDebug()) {
-                throw new DCException("Log path '{$path}' is not writable. Make sure your logger.path of config.");
-            }
-            $logger->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, $level));
-            $logger->warning("Log path '{$path}' is not writable. Make sure your logger.path of config.");
-            $logger->warning("error_log() is used for application logger instead at this time.");
-        }
-
-        return $logger;
     }
 
     protected function createRenderer()


### PR DESCRIPTION
# description

We discussed that how we can use our favorite logger instance. https://github.com/mercari/dietcube/pull/11

The best idea from @sotarok is moving `createLogger()` from `Dispatcher` to `Application` so that we can override `createLogger()` in our own `Application`.

I just implemented this idea.
So, please take a look at this PR!
