### PR TITLE
Use closure when initialize render

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -74,7 +74,9 @@ class Dispatcher
         }
 
         if (!isset($this->container['app.renderer'])) {
-            $this->container['app.renderer'] = $this->createRenderer();
+            $this->container['app.renderer'] = function () {
+                return $this->createRenderer();
+            };
         }
 
         $this->app->config($this->container);


### PR DESCRIPTION
### summary

want to use closure when initializing Twig renderer.
### detail

When we use `Controller::json`, we don't use Twig renderer because the response is a JSON encoded string. By the way, even if any request, we always initialize Twig renderer in `Dispatcher.php`. Because of this twig initialization, this framework's performance may be low when using `Controller::json`. So I want to use closure when initializing Twig renderer.
## Using `ab` command, I measured the performance.
### example

``` php
// TopController.php
    public function end_point()
    {
        return $this->json([
            'test' => 'hoge'
        ]);
    }

// Route.php
['GET', '/end_point', 'Top::end_point'],
```

`ab -n 1000 -c 100 http://127.0.0.1:8999/end_point`
### result summary
- `Requests per second` Improved (222.98 → 263.56)
- `Connection Times` Improved
### before applying this commit

```
...

Document Path:          /end_point
Document Length:        15 bytes

Concurrency Level:      100
Time taken for tests:   4.485 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      144000 bytes
HTML transferred:       15000 bytes
Requests per second:    222.98 [#/sec] (mean)
Time per request:       448.479 [ms] (mean)
Time per request:       4.485 [ms] (mean, across all concurrent requests)
Transfer rate:          31.36 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.9      0       4
Processing:     6  427  73.3    447     474
Waiting:        6  427  73.3    446     474
Total:         11  427  72.5    447     476

Percentage of the requests served within a certain time (ms)
  50%    447
...
 100%    476 (longest request)
```
### after applying this commit

```
...

Document Path:          /end_point
Document Length:        15 bytes

Concurrency Level:      100
Time taken for tests:   3.794 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      144000 bytes
HTML transferred:       15000 bytes
Requests per second:    263.56 [#/sec] (mean)
Time per request:       379.422 [ms] (mean)
Time per request:       3.794 [ms] (mean, across all concurrent requests)
Transfer rate:          37.06 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.8      0       4
Processing:     4  361  65.7    379     389
Waiting:        4  360  65.7    378     389
Total:          8  361  65.0    379     389

Percentage of the requests served within a certain time (ms)
  50%    379
...
 100%    389 (longest request)
```
