### PR TITLE
Already fabpot/php-cs-fixer package is abandoned.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "5.1.x",
-        "fabpot/php-cs-fixer": "1.11.x",
-        "phpunit/php-code-coverage": "3.1.x"
+        "phpunit/php-code-coverage": "3.1.x",
+        "friendsofphp/php-cs-fixer": "^1.12"
     },
     "scripts": {
       "test": "phpunit",


### PR DESCRIPTION
Already fabpot/php-cs-fixer package is abandoned and no longer maintained, so we have to use the friendsofphp/php-cs-fixer.
https://packagist.org/packages/fabpot/php-cs-fixer
