### PR TITLE
Add detail message to exception log

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -177,7 +177,11 @@ class Dispatcher
 
         $action_result = "";
 
-        $logger->error('Error occurred. ', ['error' => get_class($errors), 'message' => $errors->getMessage()]);
+        $logger->error('Error occurred. ', [
+            'error'     => get_class($errors),
+            'message'   => $errors->getMessage(),
+            'trace'     => $errors->getTraceAsString(),
+        ]);
         if ($this->app->isDebug()) {
             $debug_controller = isset($this->container['app.debug_controller'])
                 ? $this->container['app.debug_controller']


### PR DESCRIPTION
Since the content of the log output by handleError is too small,
changed to output trace information.