### PR TITLE
receive error as an argument

### DIFF
--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -9,10 +9,10 @@ use Dietcube\Controller;
 
 class ErrorController extends Controller implements ErrorControllerInterface
 {
-    public function notFound()
+    public function notFound(\Exception $error)
     {
         $this->getResponse()->setStatusCode(404);
-        return $this->render('error404');
+        return $this->render('error404', ['error' => $error]);
     }
 
     public function methodNotAllowed()

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -15,10 +15,10 @@ class ErrorController extends Controller implements ErrorControllerInterface
         return $this->render('error404', ['error' => $error]);
     }
 
-    public function methodNotAllowed()
+    public function methodNotAllowed(\Exception $error)
     {
         $this->getResponse()->setStatusCode(403);
-        return $this->render('error403');
+        return $this->render('error403', ['error' => $error]);
     }
 
     public function internalError(\Exception $error)

--- a/src/Controller/ErrorControllerInterface.php
+++ b/src/Controller/ErrorControllerInterface.php
@@ -9,7 +9,7 @@ interface ErrorControllerInterface
 {
     public function notFound(\Exception $error);
 
-    public function methodNotAllowed();
+    public function methodNotAllowed(\Exception $error);
 
     public function internalError(\Exception $error);
 }

--- a/src/Controller/ErrorControllerInterface.php
+++ b/src/Controller/ErrorControllerInterface.php
@@ -7,7 +7,7 @@ namespace Dietcube\Controller;
 
 interface ErrorControllerInterface
 {
-    public function notFound();
+    public function notFound(\Exception $error);
 
     public function methodNotAllowed();
 


### PR DESCRIPTION
As `internalError` action passes $error to renderer,

```
    public function internalError(\Exception $error)
    {
        $this->getResponse()->setStatusCode(500);
        return $this->render('error500', ['error' => $error]);
    }
```

 I think it is natural and useful for `notFound` action to do the same.
