### PR TITLE
Fix ci failures above php 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.4 || ^7.4",
-        "friendsofphp/php-cs-fixer": "^2.7"
+        "friendsofphp/php-cs-fixer": "^2.7 !=2.16.1"
     },
     "scripts": {
       "test": "phpunit",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,15 @@
 <phpunit
     bootstrap="./tests/bootstrap.php"
-    addUncoveredFilesFromWhitelist="true"
-    processUncoveredFilesFromWhitelist="true"
-    stopOnFailure="false"
-    colors="auto">
+    stopOnFailure="false">
     <testsuites>
-        <testsuite>
+        <testsuite name="test">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
     <filter>
-      <whitelist processUncoveredFilesFromWhitelist="true">
+      <whitelist
+        addUncoveredFilesFromWhitelist="true"
+        processUncoveredFilesFromWhitelist="true">
         <directory suffix=".php">./src</directory>
         <exclude>
           <directory suffix=".php">./tests</directory>
@@ -19,7 +18,7 @@
       </whitelist>
     </filter>
     <logging>
-        <log type="junit" target="build/junit/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="build/junit/junit.xml" />
         <log type="coverage-clover" target="build/coverage/clover.xml"/>
         <log type="coverage-html" target="build/coverage/html/"/>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>


### PR DESCRIPTION
# What is this?

fix ci errors.

1. by follow usage change about phpunit.xml's attribute.
2. pinning php-cs-fixer version.

# Details

## Deleted `colors="auto"`.
currently, `colors` value must be `true` or `false`, and default is `auto`.
(and all current supported versions are default `auto`)
see also: https://github.com/sebastianbergmann/phpunit/pull/1527

## Move whitelist setting attributes into `whitelist` tag attributes
targets:
- `addUncoveredFilesFromWhitelist`
- `processUncoveredFilesFromWhitelist`
those two kind of attributes have deleted from `phpunit` tag.

## Deleted `logIncompleteSkipped` attribute
`logIncompleteSkipped` is no longer allowed in phpunit.xml.
and because, we have no `skipped` test, we don't need it.
so, simply I delete it.

## Add testsuite `name`
In latest version, `name` attribute is must be set.

## avoiding php-cs-fixer bug #4684

avoiding https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4684
This bug is only in 2.16.1, so, on composer.json, set `!=2.16.1`.

---


Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

---

↑ok, I agree to mercari-CLA