### PR TITLE
Leap forward to 7.4 with preparing support for 8.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ vendor/*
 build/
 composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 composer.lock
 .php_cs.cache
 .phpunit.result.cache
+.php-version

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,7 +8,6 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        '@PHP74Migration' => true,
     ])
     ->setFinder($finder)
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,6 +8,7 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
+        '@PHP74Migration' => true,
     ])
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: php
 sudo: false
 
 php:
-  - 7.2
   - 7.3
   - 7.4
+  - 8.0
   - hhvm
 
 before_script:
@@ -17,4 +17,6 @@ script:
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php:
+      - hhvm
+      - 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: php
 sudo: false
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "require": {
         "nikic/fast-route": "0.7.x",
         "twig/twig": "3.3.x",
-        "pimple/pimple": "3.0.x",
-        "psr/log": "1.0.0",
-        "monolog/monolog": "1.17.x",
-        "symfony/event-dispatcher": "3.0.x"
+        "pimple/pimple": "3.3.x",
+        "psr/log": "1.1.*",
+        "monolog/monolog": "2.2.x",
+        "symfony/event-dispatcher": "5.2.x"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*",
-        "friendsofphp/php-cs-fixer": "^2.7 !=2.16.1"
+        "friendsofphp/php-cs-fixer": "2.18.*"
     },
     "scripts": {
       "test": "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "pimple/pimple": "3.3.x",
         "psr/log": "1.1.*",
         "monolog/monolog": "2.2.x",
-        "symfony/event-dispatcher": "5.2.x"
+        "symfony/event-dispatcher": "5.2.x",
+        "php": ">=7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "8.*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/event-dispatcher": "5.2.x"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.*",
+        "phpunit/phpunit": "8.*",
         "friendsofphp/php-cs-fixer": "2.18.*"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "nikic/fast-route": "0.7.x",
-        "twig/twig": "1.23.x",
+        "twig/twig": "3.3.x",
         "pimple/pimple": "3.0.x",
         "psr/log": "1.0.0",
         "monolog/monolog": "1.17.x",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "psr/log": "1.1.*",
         "monolog/monolog": "2.2.x",
         "symfony/event-dispatcher": "5.2.x",
-        "php": ">=7.2"
+        "php": ">=7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "8.*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/event-dispatcher": "3.0.x"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.4 || ^7.4",
+        "phpunit/phpunit": "9.*",
         "friendsofphp/php-cs-fixer": "^2.7"
     },
     "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     </testsuites>
     <logging>
         <junit outputFile="build/junit/junit.xml"/>
-        <text outputFile="php://stdout"/>
     </logging>
     <coverage
             includeUncoveredFiles="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,8 +9,27 @@
         </testsuite>
     </testsuites>
     <logging>
+        <!-- Remove <log> elements when PHP unit bumped 9.X -->
+        <log type="junit" target="build/junit/junit.xml" />
+        <log type="coverage-html" target="build/coverage/html/" />
+        <log type="coverage-clover" target="build/coverage/clover.xml" />
+        <!-- For PHP unit 9.X --> <!--
         <junit outputFile="build/junit/junit.xml"/>
+        -->
     </logging>
+    <!-- Remove <filter> element when PHP unit bumped 9.X -->
+    <filter>
+        <whitelist
+                addUncoveredFilesFromWhitelist="true"
+                processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+            <exclude>
+                <directory suffix=".php">./tests</directory>
+                <directory suffix=".twig">./src/template</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <!-- For PHP unit 9.X --> <!--
     <coverage
             includeUncoveredFiles="true"
             processUncoveredFiles="true"
@@ -27,4 +46,5 @@
             <directory suffix=".twig">./src/template</directory>
         </exclude>
     </coverage>
+    -->
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     bootstrap="./tests/bootstrap.php"
-    addUncoveredFilesFromWhitelist="true"
-    processUncoveredFilesFromWhitelist="true"
     stopOnFailure="false"
-    colors="auto">
+    colors="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="test">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-      <whitelist processUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">./src</directory>
-        <exclude>
-          <directory suffix=".php">./tests</directory>
-          <directory suffix=".twig">./src/template</directory>
-        </exclude>
-      </whitelist>
-    </filter>
     <logging>
-        <log type="junit" target="build/junit/junit.xml" logIncompleteSkipped="false"/>
-        <log type="coverage-clover" target="build/coverage/clover.xml"/>
-        <log type="coverage-html" target="build/coverage/html/"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <junit outputFile="build/junit/junit.xml"/>
+        <text outputFile="php://stdout"/>
     </logging>
+    <coverage
+            includeUncoveredFiles="true"
+            processUncoveredFiles="true"
+    >
+        <report>
+            <html outputDirectory="build/coverage/html/"/>
+            <clover outputFile="build/coverage/clover.xml" />
+        </report>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./tests</directory>
+            <directory suffix=".twig">./src/template</directory>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/src/Application.php
+++ b/src/Application.php
@@ -64,7 +64,7 @@ abstract class Application
                 continue;
             }
 
-            $config = array_merge($config, require $load_config_file);
+            $config[] = array_merge($config, require $load_config_file);
         }
 
         $this->config = new Config($config);

--- a/src/Components/ArrayResourceGetterTrait.php
+++ b/src/Components/ArrayResourceGetterTrait.php
@@ -9,6 +9,11 @@ trait ArrayResourceGetterTrait
 {
     protected $_array_resource = [];
 
+    /**
+     * @param null $key
+     * @param null $default
+     * @return array|mixed|null
+     */
     public function getResource($key = null, $default = null)
     {
         if ($key === null) {
@@ -17,23 +22,25 @@ trait ArrayResourceGetterTrait
 
         $key_parts = explode('.', $key);
         $value = $this->_array_resource;
-        foreach ($key_parts as $key) {
+        foreach ($key_parts as $key_part) {
             if (!is_array($value)) {
                 return $default;
-            } elseif (!array_key_exists($key, $value)) {
+            }
+
+            if (!array_key_exists($key_part, $value)) {
                 return $default;
             }
-            $value = $value[$key];
+            $value = $value[$key_part];
         }
         return $value;
     }
 
-    public function getResourceData()
+    public function getResourceData(): array
     {
         return $this->_array_resource;
     }
 
-    public function clearResource()
+    public function clearResource(): void
     {
         $this->_array_resource = [];
     }

--- a/src/Components/ArrayResourceGetterTrait.php
+++ b/src/Components/ArrayResourceGetterTrait.php
@@ -1,12 +1,10 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Components;
 
 trait ArrayResourceGetterTrait
 {
+    /** @var array */
     protected $_array_resource = [];
 
     /**

--- a/src/Components/ArrayResourceTrait.php
+++ b/src/Components/ArrayResourceTrait.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Components;
 
@@ -10,21 +7,21 @@ trait ArrayResourceTrait
     use ArrayResourceGetterTrait;
 
     /**
-     * @param
-     * @param
+     * @param mixed $key
+     * @param mixed $value
      */
-    public function setResource($key, $value)
+    public function setResource($key, $value): void
     {
         $key_parts = explode('.', $key);
         $ref_value = &$this->_array_resource;
-        foreach ($key_parts as $key) {
+        foreach ($key_parts as $key_part) {
             if (!is_array($ref_value)) {
                 $ref_value = [];
             }
-            if (!array_key_exists($key, $ref_value)) {
-                $ref_value[$key] = [];
+            if (!array_key_exists($key_part, $ref_value)) {
+                $ref_value[$key_part] = [];
             }
-            $ref_value = &$ref_value[$key];
+            $ref_value = &$ref_value[$key_part];
         }
         $ref_value = $value;
     }

--- a/src/Components/ContainerAwareTrait.php
+++ b/src/Components/ContainerAwareTrait.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Components;
 
@@ -10,9 +7,9 @@ use Pimple\Container;
 trait ContainerAwareTrait
 {
     /**
-     * @var Container
+     * @var Container|null
      */
-    protected $container = null;
+    protected $container;
 
     /**
      * @param Container $container

--- a/src/Components/ContainerAwareTrait.php
+++ b/src/Components/ContainerAwareTrait.php
@@ -16,8 +16,9 @@ trait ContainerAwareTrait
 
     /**
      * @param Container $container
+     * @return self
      */
-    public function setContainer(Container $container)
+    public function setContainer(Container $container): self
     {
         $this->container = $container;
 

--- a/src/Components/LoggerAwareTrait.php
+++ b/src/Components/LoggerAwareTrait.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Components;
 
@@ -9,9 +6,10 @@ use Psr\Log\LoggerInterface;
 
 trait LoggerAwareTrait
 {
-    protected $logger = null;
+    /** @var LoggerInterface|null */
+    protected $logger;
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube;
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -71,7 +71,7 @@ class Controller
     {
         $template = $this->findTemplate($name);
 
-        return $this->get('app.renderer')->render($template, array_merge($this->view_vars, $vars));
+        return $this->get('app.renderer')->render($template, array_merge($this->view_vars ?: [], $vars));
     }
 
     protected function redirect($uri, $code = 302)

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -6,13 +6,19 @@ use Pimple\Container;
 
 class Controller
 {
-    const ACTION_NOT_FOUND = 'notFound';
-    const ACTION_METHOD_NOT_ALLOWED = 'methodNotAllowed';
-    const ACTION_INTERNAL_ERROR = 'internalError';
+    public const ACTION_NOT_FOUND = 'notFound';
+    public const ACTION_METHOD_NOT_ALLOWED = 'methodNotAllowed';
+    public const ACTION_INTERNAL_ERROR = 'internalError';
 
+    /**
+     * @var Container
+     */
     protected $container;
 
-    protected $view_vars;
+    /**
+     * @var array
+     */
+    protected $view_vars = [];
 
     public function __construct(Container $container)
     {
@@ -20,9 +26,11 @@ class Controller
     }
 
     /**
+     * @param mixed $key
+     * @param null $value
      * @return $this
      */
-    public function setVars($key, $value = null)
+    public function setVars($key, $value = null): self
     {
         if (is_array($key)) {
             $this->view_vars = array_merge($this->view_vars, $key);
@@ -33,7 +41,7 @@ class Controller
         return $this;
     }
 
-    protected function isPost()
+    protected function isPost(): bool
     {
         if (stripos($this->container['global.server']->get('REQUEST_METHOD'), 'post') === 0) {
             return true;
@@ -42,48 +50,83 @@ class Controller
         return false;
     }
 
+    /**
+     * @param $name
+     * @return mixed
+     */
     protected function get($name)
     {
         return $this->container[$name];
     }
 
+    /**
+     * @param mixed $name
+     * @param mixed $default
+     * @return mixed
+     */
     protected function query($name, $default = null)
     {
         return $this->container['global.get']->get($name, $default);
     }
 
+    /**
+     * @param mixed $name
+     * @param mixed $default
+     * @return mixed
+     */
     protected function body($name = null, $default = null)
     {
         return $this->container['global.post']->get($name, $default);
     }
 
+    /**
+     * @param mixed $handler
+     * @param array $data
+     * @param array $query_params
+     * @param bool $is_absolute
+     * @return mixed
+     */
     protected function generateUrl($handler, array $data = [], array $query_params = [], $is_absolute = false)
     {
         return $this->container['router']->url($handler, $data, $query_params, $is_absolute);
     }
 
-    protected function findTemplate($name)
+    protected function findTemplate($name): string
     {
         return $name . $this->get('app')->getTemplateExt();
     }
 
+    /**
+     * @param $name
+     * @param array $vars
+     * @return mixed
+     *
+     * The Twig render returning type is `string`.
+     * But we aren't determinable to the returning type because a user can change component by `get('app.renderer')`.
+     */
     protected function render($name, array $vars = [])
     {
         $template = $this->findTemplate($name);
 
-        return $this->get('app.renderer')->render($template, array_merge($this->view_vars ?: [], $vars));
+        return $this->get('app.renderer')->render($template, array_merge($this->view_vars, $vars));
     }
 
-    protected function redirect($uri, $code = 302)
+    /**
+     * @param mixed $uri
+     * @param int $code
+     * @return void
+     */
+    protected function redirect($uri, $code = 302): void
     {
         $response = $this->getResponse();
 
         $response->setStatusCode($code);
         $response->setHeader('Location', $uri);
-
-        return null;
     }
 
+    /**
+     * @return mixed
+     */
     protected function getResponse()
     {
         return $this->get('response');
@@ -96,7 +139,7 @@ class Controller
      * @param string|null $charset
      * @return string JSON encoded string
      */
-    protected function json($vars, $charset = 'utf-8')
+    protected function json(array $vars, $charset = 'utf-8')
     {
         $this->getResponse()->setHeader('Content-Type', 'application/json;charset=' . $charset);
 

--- a/src/Controller/DebugController.php
+++ b/src/Controller/DebugController.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Controller;
 

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Controller;
 

--- a/src/Controller/ErrorControllerInterface.php
+++ b/src/Controller/ErrorControllerInterface.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Controller;
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -20,6 +20,9 @@ use FastRoute\Dispatcher as RouteDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
 use Monolog\Logger;
+use Twig\Environment;
+use Twig\Extension\DebugExtension;
+use Twig\Loader\FilesystemLoader;
 
 class Dispatcher
 {
@@ -87,8 +90,8 @@ class Dispatcher
     protected function createRenderer()
     {
         $config = $this->container['app.config'];
-        $loader = new \Twig_Loader_Filesystem($this->app->getTemplateDir());
-        $twig = new \Twig_Environment($loader, [
+        $loader = new FilesystemLoader($this->app->getTemplateDir());
+        $twig = new Environment($loader, [
             'debug' => $config->get('debug', false),
             'cache' => $config->get('twig.cache', false),
             'charset' => $config->get('twig.charset', 'utf-8'),
@@ -102,7 +105,7 @@ class Dispatcher
 
         if ($this->app->isDebug()) {
             // add built-in debug template path
-            $twig->addExtension(new \Twig_Extension_Debug());
+            $twig->addExtension(new DebugExtension());
             $loader->addPath(__DIR__ . '/template/debug', 'debug');
         }
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -205,7 +205,7 @@ class Dispatcher
         if (is_callable($handler)) {
             $executable = $handler;
         } else {
-            list($controller_name, $action_name) = $this->app->getControllerByHandler($handler);
+            [$controller_name, $action_name] = $this->app->getControllerByHandler($handler);
 
             if (!class_exists($controller_name)) {
                 throw new DCException("Controller {$controller_name} is not exists.");

--- a/src/Events/BootEvent.php
+++ b/src/Events/BootEvent.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Events;
 

--- a/src/Events/DietcubeEventAbstract.php
+++ b/src/Events/DietcubeEventAbstract.php
@@ -1,14 +1,11 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Events;
 
 use Dietcube\Application;
 use Symfony\Component\EventDispatcher\Event;
 
-class DietcubeEventAbstract extends Event
+abstract class DietcubeEventAbstract extends Event
 {
     /**
      * @var Application
@@ -18,7 +15,7 @@ class DietcubeEventAbstract extends Event
     /**
      * @return Application
      */
-    public function getApplication()
+    public function getApplication(): Application
     {
         return $this->app;
     }

--- a/src/Events/DietcubeEvents.php
+++ b/src/Events/DietcubeEvents.php
@@ -7,13 +7,13 @@ namespace Dietcube\Events;
 
 final class DietcubeEvents
 {
-    const BOOT = 'dietcube.boot';
+    public const BOOT = 'dietcube.boot';
 
-    const ROUTING = 'dietcube.routing';
+    public const ROUTING = 'dietcube.routing';
 
-    const EXECUTE_ACTION = 'dietcube.execute_action';
+    public const EXECUTE_ACTION = 'dietcube.execute_action';
 
-    const FILTER_RESPONSE = 'dietcube.filter_response';
+    public const FILTER_RESPONSE = 'dietcube.filter_response';
 
-    const FINISH_REQUEST = 'dietcube.finish_request';
+    public const FINISH_REQUEST = 'dietcube.finish_request';
 }

--- a/src/Events/ExecuteActionEvent.php
+++ b/src/Events/ExecuteActionEvent.php
@@ -10,12 +10,15 @@ use Dietcube\Response;
 
 class ExecuteActionEvent extends DietcubeEventAbstract
 {
+    /** @var callable  */
     protected $executable;
+    /** @var array */
     protected $vars = [];
 
+    /** @var string */
     protected $result = "";
 
-    public function __construct(Application $app, $executable, array $vars)
+    public function __construct(Application $app, callable $executable, array $vars)
     {
         $this->app = $app;
         $this->executable = $executable;
@@ -23,17 +26,10 @@ class ExecuteActionEvent extends DietcubeEventAbstract
     }
 
     /**
-     * @return Application
-     */
-    public function getApplication()
-    {
-        return $this->app;
-    }
-
-    /**
      * @param callable $executable
+     * @return ExecuteActionEvent
      */
-    public function setExecutable($executable)
+    public function setExecutable(callable $executable): self
     {
         if (!is_callable($executable)) {
             throw new \InvalidArgumentException("Passed argument for setExecutable is not callable.");
@@ -49,10 +45,11 @@ class ExecuteActionEvent extends DietcubeEventAbstract
      * e.g. User::login
      *
      * @param string $handler
+     * @return ExecuteActionEvent
      */
-    public function setExecutableByHandler($handler)
+    public function setExecutableByHandler(string $handler): self
     {
-        list($controller_name, $action_name) = $this->app->getControllerByHandler($handler);
+        [$controller_name, $action_name] = $this->app->getControllerByHandler($handler);
         $controller = $this->app->createController($controller_name);
 
         $this->setExecutable([$controller, $action_name]);
@@ -63,15 +60,16 @@ class ExecuteActionEvent extends DietcubeEventAbstract
     /**
      * @return callable executable
      */
-    public function getExecutable()
+    public function getExecutable(): callable
     {
         return $this->executable;
     }
 
     /**
      * @param array $vars
+     * @return ExecuteActionEvent
      */
-    public function setVars(array $vars)
+    public function setVars(array $vars): self
     {
         $this->vars = $vars;
 
@@ -81,15 +79,16 @@ class ExecuteActionEvent extends DietcubeEventAbstract
     /**
      * @return array
      */
-    public function getVars()
+    public function getVars(): array
     {
         return $this->vars;
     }
 
     /**
      * @param string $result
+     * @return ExecuteActionEvent
      */
-    public function setResult($result)
+    public function setResult(string $result): self
     {
         $this->result = $result;
 
@@ -99,7 +98,7 @@ class ExecuteActionEvent extends DietcubeEventAbstract
     /**
      * @return string
      */
-    public function getResult()
+    public function getResult(): string
     {
         return $this->result;
     }

--- a/src/Events/FilterResponseEvent.php
+++ b/src/Events/FilterResponseEvent.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace Dietcube\Events;
 
@@ -24,16 +21,18 @@ class FilterResponseEvent extends DietcubeEventAbstract
     /**
      * @return Response
      */
-    public function getResponse()
+    public function getResponse(): Response
     {
         return $this->response;
     }
 
     /**
      * @param Response $response
+     * @return FilterResponseEvent
      */
-    public function setResponse(Response $response)
+    public function setResponse(Response $response): self
     {
         $this->response = $response;
+        return $this;
     }
 }

--- a/src/Events/FinishRequestEvent.php
+++ b/src/Events/FinishRequestEvent.php
@@ -24,16 +24,18 @@ class FinishRequestEvent extends DietcubeEventAbstract
     /**
      * @return Response
      */
-    public function getResponse()
+    public function getResponse(): Response
     {
         return $this->response;
     }
 
     /**
      * @param Response $response
+     * @return FinishRequestEvent
      */
-    public function setResponse(Response $response)
+    public function setResponse(Response $response): self
     {
         $this->response = $response;
+        return $this;
     }
 }

--- a/src/Events/RoutingEvent.php
+++ b/src/Events/RoutingEvent.php
@@ -7,9 +7,11 @@ namespace Dietcube\Events;
 
 use Dietcube\Application;
 use Dietcube\Router;
+use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
 
 class RoutingEvent extends DietcubeEventAbstract
 {
+    /** @var Router  */
     protected $router;
 
     protected $handler;
@@ -21,45 +23,56 @@ class RoutingEvent extends DietcubeEventAbstract
         $this->router = $router;
     }
 
-    public function getRouter()
+    public function getRouter(): Router
     {
         return $this->router;
     }
 
-    public function setRouter(Router $router)
+    public function setRouter(Router $router): self
     {
         $this->router = $router;
+        return $this;
     }
 
-    public function setHandler($handler)
+    public function setHandler($handler): self
     {
         $this->handler = $handler;
 
         return $this;
     }
 
-    public function getHandler($handler)
+    /**
+     * @param mixed $_handler Deprecated.
+     * @return mixed
+     */
+    public function getHandler($_handler = null)
     {
         return $this->handler;
     }
 
-    public function setVars(array $vars)
+    public function setVars(array $vars): self
     {
         $this->vars = $vars;
+        return $this;
     }
 
-    public function getVars(array $vars)
+    /**
+     * @param array $_vars Deprecated.
+     * @return array
+     */
+    public function getVars(array $_vars = []): array
     {
         return $this->vars;
     }
 
-    public function setRouteInfo($handler, array $vars = [])
+    public function setRouteInfo($handler, array $vars = []): self
     {
         $this->handler = $handler;
         $this->vars = $vars;
+        return $this;
     }
 
-    public function getRouteInfo()
+    public function getRouteInfo(): array
     {
         return [$this->handler, $this->vars];
     }

--- a/src/Events/RoutingEvent.php
+++ b/src/Events/RoutingEvent.php
@@ -7,7 +7,6 @@ namespace Dietcube\Events;
 
 use Dietcube\Application;
 use Dietcube\Router;
-use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
 
 class RoutingEvent extends DietcubeEventAbstract
 {

--- a/src/Response.php
+++ b/src/Response.php
@@ -13,8 +13,11 @@ class Response
 {
     use LoggerAwareTrait;
 
-    /** @const array Map of standard HTTP status code/reason phrases */
-    const PHRASES = [
+    /**
+     * @var array<int, string>
+     * @const array Map of standard HTTP status code/reason phrases
+     */
+    public const PHRASES = [
         100 => 'Continue',
         101 => 'Switching Protocols',
         102 => 'Processing',
@@ -82,7 +85,7 @@ class Response
     protected $status_code = 200;
 
     /** @var null|string */
-    protected $body = null;
+    protected $body;
 
     protected $headers = [];
 
@@ -98,9 +101,10 @@ class Response
     }
 
     /**
+     * @param int|string $status_code
      * @return $this
      */
-    public function setStatusCode($status_code)
+    public function setStatusCode($status_code): self
     {
         if (null === self::PHRASES[$this->status_code]) {
             throw new \InvalidArgumentException("Invalid status code '{$this->status_code}'");
@@ -115,7 +119,7 @@ class Response
     /**
      * @return int
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->status_code;
     }
@@ -123,7 +127,7 @@ class Response
     /**
      * @return $this
      */
-    public function setBody($body)
+    public function setBody($body): self
     {
         $this->body = $body;
 
@@ -131,9 +135,10 @@ class Response
     }
 
     /**
-     * @return $this
+     * @return mixed $this
+     * @throws \InvalidArgumentException
      */
-    public function setReasonPhrase($phrase = null)
+    public function setReasonPhrase($phrase = null): self
     {
         if ($phrase !== null) {
             $this->reason_phrase = $phrase;
@@ -151,7 +156,7 @@ class Response
     /**
      * @return string
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): ?string
     {
         return $this->reason_phrase;
     }
@@ -159,19 +164,19 @@ class Response
     /**
      * @return string|null
      */
-    public function getBody()
+    public function getBody(): ?string
     {
         return $this->body;
     }
 
-    public function sendBody()
+    public function sendBody(): void
     {
         if ($this->body !== null) {
             echo $this->body;
         }
     }
 
-    public function sendHeaders()
+    public function sendHeaders(): self
     {
         if (headers_sent()) {
             $this->logger || $this->logger->error('Header already sent.');
@@ -185,15 +190,16 @@ class Response
         }
     }
 
-    public function sendHttpHeader()
+    public function sendHttpHeader(): void
     {
         header("HTTP/{$this->version} {$this->status_code} {$this->reason_phrase}", true);
     }
 
     /**
+     * @param array $headers
      * @return $this
      */
-    public function setHeaders(array $headers)
+    public function setHeaders(array $headers): self
     {
         foreach ($headers as $header => $value) {
             $this->setHeader($header, $value);
@@ -203,9 +209,11 @@ class Response
     }
 
     /**
+     * @param $header
+     * @param $value
      * @return $this
      */
-    public function setHeader($header, $value)
+    public function setHeader($header, $value): self
     {
         $header = trim($header);
         if (!is_array($value)) {

--- a/src/Router.php
+++ b/src/Router.php
@@ -15,13 +15,16 @@ class Router
      */
     protected $dispatcher;
 
+    /**
+     * @var Container
+     */
     protected $container;
 
-    protected $route_info = null;
+    protected $route_info;
 
-    protected $dispatched_http_method = null;
+    protected $dispatched_http_method;
 
-    protected $dispatched_url = null;
+    protected $dispatched_url;
 
     /**
      * @var RouteInterface[]
@@ -36,15 +39,16 @@ class Router
     }
 
     /**
+     * @param RouteInterface $route
      * @return $this
      */
-    public function addRoute(RouteInterface $route)
+    public function addRoute(RouteInterface $route): self
     {
         $this->routes[] = $route;
         return $this;
     }
 
-    public function init()
+    public function init(): void
     {
         $collector = new RouteCollector(
             new StdRouteParser(),
@@ -52,7 +56,7 @@ class Router
         );
 
         foreach ($this->routes as $route) {
-            foreach ($route->definition($this->container) as list($method, $route_name, $handler_name)) {
+            foreach ($route->definition($this->container) as [$method, $route_name, $handler_name]) {
                 $collector->addRoute($method, $route_name, $handler_name);
             }
         }
@@ -67,7 +71,7 @@ class Router
      * @param string $url
      * @return array
      */
-    public function dispatch($http_method, $url)
+    public function dispatch(string $http_method, string $url): array
     {
         if ($this->dispatcher === null) {
             throw new \RuntimeException('Route dispatcher is not initialized');
@@ -93,7 +97,7 @@ class Router
      * @throws \RuntimeException         If named route does not exist
      * @throws \InvalidArgumentException If required data not provided
      */
-    public function url($handler, array $data = [], array $query_params = [], $is_absolute = false)
+    public function url(string $handler, array $data = [], array $query_params = [], $is_absolute = false): string
     {
         if ($this->named_routes === null) {
             $this->buildNameIndex();
@@ -104,7 +108,7 @@ class Router
         }
 
         $route = $this->named_routes[$handler];
-        $url = preg_replace_callback('/{([^}]+)}/', function ($match) use ($data) {
+        $url = preg_replace_callback('/{([^}]+)}/', static function ($match) use ($data) {
             $segment_name = explode(':', $match[1])[0];
             if (!isset($data[$segment_name])) {
                 throw new \InvalidArgumentException('Missing data for URL segment: ' . $segment_name);
@@ -124,24 +128,30 @@ class Router
     }
 
     /**
-     * @return $this
+     * @return mixed
      */
     public function getRouteInfo()
     {
         return $this->route_info;
     }
 
+    /**
+     * @return mixed
+     */
     public function getDispatchedMethod()
     {
         return $this->dispatched_http_method;
     }
 
+    /**
+     * @return mixed
+     */
     public function getDispatchedUrl()
     {
         return $this->dispatched_url;
     }
 
-    protected function buildNameIndex()
+    protected function buildNameIndex(): void
     {
         $this->named_routes = [];
         foreach ($this->routes as $route) {

--- a/src/Router.php
+++ b/src/Router.php
@@ -155,7 +155,7 @@ class Router
     {
         $this->named_routes = [];
         foreach ($this->routes as $route) {
-            foreach ($route->definition($this->container) as list($method, $route_name, $handler_name)) {
+            foreach ($route->definition($this->container) as [$method, $route_name, $handler_name]) {
                 if ($handler_name) {
                     $this->named_routes[$handler_name] = $route_name;
                 }

--- a/src/Twig/DietcubeExtension.php
+++ b/src/Twig/DietcubeExtension.php
@@ -14,12 +14,12 @@ class DietcubeExtension extends AbstractExtension
 {
     use ContainerAwareTrait;
 
-    public function getName()
+    public function getName(): string
     {
         return 'dietcube';
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('url', [$this, 'url']),
@@ -36,7 +36,7 @@ class DietcubeExtension extends AbstractExtension
      * @param bool $is_absolute
      * @return string url
      */
-    public function url($handler, array $data = [], array $query_params = [], $is_absolute = false)
+    public function url(string $handler, array $data = [], array $query_params = [], $is_absolute = false): string
     {
         $router = $this->container['router'];
         return $router->url($handler, $data, $query_params, $is_absolute);
@@ -50,7 +50,7 @@ class DietcubeExtension extends AbstractExtension
      * @param array $query_params
      * @return string url
      */
-    public function absoluteUrl($handler, array $data = [], array $query_params = [])
+    public function absoluteUrl(string $handler, array $data = [], array $query_params = []): string
     {
         return $this->url($handler, $data, $query_params, true);
     }

--- a/src/Twig/DietcubeExtension.php
+++ b/src/Twig/DietcubeExtension.php
@@ -7,8 +7,10 @@ namespace Dietcube\Twig;
 
 use Dietcube\Components\ContainerAwareTrait;
 use Pimple\Container;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class DietcubeExtension extends \Twig_Extension
+class DietcubeExtension extends AbstractExtension
 {
     use ContainerAwareTrait;
 
@@ -20,8 +22,8 @@ class DietcubeExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('url', [$this, 'url']),
-            new \Twig_SimpleFunction('absolute_url', [$this, 'absoluteUrl']),
+            new TwigFunction('url', [$this, 'url']),
+            new TwigFunction('absolute_url', [$this, 'absoluteUrl']),
         ];
     }
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -21,7 +21,7 @@ class ApplicationTest extends TestCase
         $container = new Container();
         $container['global.server'] = new Parameters($_SERVER);
 
-        $app = new MockApplication(__DIR__, 'development');
+        $app = new DummyApplication(__DIR__, 'development');
 
         $this->assertEquals(__DIR__, $app->getAppRoot());
         $this->assertEquals('development', $app->getEnv());
@@ -48,12 +48,5 @@ class ApplicationTest extends TestCase
         $this->assertEquals('.html.twig', $app->getTemplateExt());
         $this->assertEquals(__DIR__ . '/config', $app->getConfigDir());
         $this->assertEquals(dirname(__DIR__) . '/tmp', $app->getTmpDir());
-    }
-}
-
-class MockApplication extends Application
-{
-    public function config(Container $container)
-    {
     }
 }

--- a/tests/Components/ContainerAwareTraitTest.php
+++ b/tests/Components/ContainerAwareTraitTest.php
@@ -6,14 +6,15 @@
 namespace Dietcube\Components;
 
 use PHPUnit\Framework\TestCase;
+use Pimple\Container;
 
 /**
  */
 class ContainerAwareTraitTest extends TestCase
 {
-    public function testToGetContainer()
+    public function testToGetContainer(): void
     {
-        $container = new \Pimple\Container();
+        $container = new Container();
         $obj = new ConcreteComponentWithContainer();
 
         // not yet set
@@ -28,7 +29,7 @@ class ConcreteComponentWithContainer
 {
     use ContainerAwareTrait;
 
-    public function getContainer()
+    public function getContainer(): ?Container
     {
         return $this->container;
     }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -5,7 +5,6 @@
 
 namespace Dietcube;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use Twig\Environment;

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -38,32 +38,29 @@ class RouterTest extends TestCase
         $this->assertSame([\FastRoute\Dispatcher::NOT_FOUND], $route_info);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testDispatchIsNotInitialized()
     {
         $router = static::createRouterWithoutInit();
 
+        $this->expectException(\RuntimeException::class);
+
         $router->dispatch('GET', '/about');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testNotExistHandler()
     {
         $router = static::createRouter();
 
+        $this->expectException(\RuntimeException::class);
+
         $router->url('Page::notExistsHandler');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testNotExistSegumentName()
     {
         $router = static::createRouter();
+
+        $this->expectException(\InvalidArgumentException::class);
 
         $router->url('User::detail', ['invalid_key_name' => 12345]);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,4 @@
 <?php
 
+require dirname(__DIR__) . '/tests/helper.php';
 require dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Dietcube;
+
+use Pimple\Container;
+
+// It should define delegation function only.
+class DummyController extends Controller
+{
+    public function doRender(string $template_name, array $vars = []): string
+    {
+        return $this->render($template_name, $vars);
+    }
+
+    public function doFindTemplate(string $template_name): string
+    {
+        return $this->findTemplate($template_name);
+    }
+}
+
+class DummyApplication extends Application
+{
+    public function config(Container $container)
+    {
+    }
+}


### PR DESCRIPTION
# Why
We are thinking of adding support for PHP 8.0.
However, it should require a major change.
So, we'll first drop off Support for 5.X and Support up to 7.4.

# What did 
To make it as easy as possible for further development.
**Also, I break backward compatibility.**

1. Drop EOL PHP supports.
2. Support 7.3, 7.4 PHP features.
3. "type declarations/hints" wherever possible.
4. Upgrade PHP Unit to 8.X
    * With fixing XML.
5. Bump up All dependencies 